### PR TITLE
Remove `DigitalOcean`'s survey

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,6 @@ Feel free to send a PR! :smile:
 
 ![](https://devrant.com/static/devrant/img/stickers-collection3.png)
 
-## Digital Ocean ![](https://img.shields.io/badge/status-ended-red.svg)
-
-- Completing this short survey will get you a Sammy sticker pack: [http://do.co/currents-survey](http://do.co/currents-survey)
-
-![](https://pbs.twimg.com/media/ClLKoRDWEAAvgqK.jpg)
-
 ## Google Assistant
 
 - Make an app for the Google Assistant available to users, get an exclusive Google Assistant t-shirt and a Google Home (if a certain amount of users engage with it)! [Reference](https://developers.google.com/actions/community/overview)


### PR DESCRIPTION
The survey has ended.

If you follow the link on the `README` you'll be redirected to this link https://digitalocean.getfeedback.com/r/zgP1S6BP/q/closed

Which shows this in the browser:
<img width="493" alt="screen shot 2018-02-21 at 09 34 40" src="https://user-images.githubusercontent.com/2642850/36470242-75a4b540-16ea-11e8-99c2-f2a93d5d6cc3.png">
