### PR TITLE
devRant changed amount of ++'s

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Sign up at [https://upscri.be/67d2fa](https://upscri.be/67d2fa) to get early acc
 
 ## devRant
 
-- Get 20 ++'s on a single rant you've posted to devRant to receive 3 free high-quality devRant laptop stickers! Or post an awesome rant that gets over 500 ++'s to receive a free devRant squishy stress ball! [Reference](https://devrant.com/free-stickers)
+- Get 30 ++'s on a single rant you've posted to devRant to receive 3 free high-quality devRant laptop stickers! Or post an awesome rant that gets over 750 ++'s to receive a free devRant squishy stress ball! [Reference](https://devrant.com/free-stickers)
 
 ![](https://devrant.com/static/devrant/img/stickers-collection3.png)
 


### PR DESCRIPTION
- [X] I've checked that there isn't a duplicate pull request.

devRant now requires 750++'s for a stressball and 30++'s for a stickerpack. Reference: https://devrant.com/free-stickers