### PR TITLE
Add Microsoft Hacktoberfest t-shirt

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Sign up at [https://upscri.be/67d2fa](https://upscri.be/67d2fa) to get early acc
 
 ## Microsoft Hacktoberfest ![](https://img.shields.io/badge/difficulty-hard-red.svg)
 
-- Make one pull request in October 2018 to any [open source Microsoft repository](https://opensource.microsoft.com/), earn a limited edition T-shirt! [Reference](https://open.microsoft.com/2018/09/18/hacktoberfest-2018-microsoft/)
+- Make one pull request in October 2018 to any [open source Microsoft repository](https://opensource.microsoft.com/), earn a limited edition T-shirt! [Reference](https://open.microsoft.com/2018/09/30/join-hacktoberfest-2018-celebration-microsoft/)
 
 ## Mullvad ![](https://img.shields.io/badge/difficulty-easy-green.svg)
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Sign up at [https://upscri.be/67d2fa](https://upscri.be/67d2fa) to get early acc
 
 - Make one pull request in October 2018 to any [open source Microsoft repository](https://opensource.microsoft.com/), earn a limited edition T-shirt! [Reference](https://open.microsoft.com/2018/09/30/join-hacktoberfest-2018-celebration-microsoft/)
 
+![](https://images.all-free-download.com/images/graphiclarge/blank_t_shirt_clip_art_19042.jpg)
+
 ## Mullvad ![](https://img.shields.io/badge/difficulty-easy-green.svg)
 
 - Send an email to [support@mullvad.net](mailto:support@mullvad.net) with "STICKERS" in the subject line. Include a postal address in the email and get an assortment of stickers sent your way. [Reference](https://www.mullvad.net/en/guides/mullvad-stickers-and-merchandise/)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Sign up at [https://upscri.be/67d2fa](https://upscri.be/67d2fa) to get early acc
 - [devRant](#devrant-) ![](https://img.shields.io/badge/difficulty-medium-yellow.svg)
 - [Google Assistant](#google-assistant-) ![](https://img.shields.io/badge/difficulty-hard-red.svg)
 - [Hacktoberfest](#hacktoberfest-) ![](https://img.shields.io/badge/difficulty-hard-red.svg)
-- [Microsoft Hacktoberfest](#microsoft-hacktoberfest-) ![](https://img.shields.io/badge/difficulty-hard-red.svg)
+- [Microsoft Hacktoberfest](#microsoft-hacktoberfest-) ![](https://img.shields.io/badge/difficulty-medium-yellow.svg)
 - [Mullvad](#mullvad-) ![](https://img.shields.io/badge/difficulty-easy-green.svg)
 - [Netlify](#netlify-) ![](https://img.shields.io/badge/difficulty-easy-green.svg)
 - [npm](#npm-) ![](https://img.shields.io/badge/difficulty-hard-red.svg)
@@ -50,7 +50,7 @@ Sign up at [https://upscri.be/67d2fa](https://upscri.be/67d2fa) to get early acc
 
 ![](https://cdn-images-1.medium.com/max/2000/1*9rG8J1r8l-LC0oRvRVoEkA.jpeg)
 
-## Microsoft Hacktoberfest ![](https://img.shields.io/badge/difficulty-hard-red.svg)
+## Microsoft Hacktoberfest ![](https://img.shields.io/badge/difficulty-medium-yellow.svg)
 
 - Make one pull request in October 2018 to any [open source Microsoft repository](https://opensource.microsoft.com/), earn a limited edition T-shirt! [Reference](https://open.microsoft.com/2018/09/30/join-hacktoberfest-2018-celebration-microsoft/)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Sign up at [https://upscri.be/67d2fa](https://upscri.be/67d2fa) to get early acc
 - [devRant](#devrant-) ![](https://img.shields.io/badge/difficulty-medium-yellow.svg)
 - [Google Assistant](#google-assistant-) ![](https://img.shields.io/badge/difficulty-hard-red.svg)
 - [Hacktoberfest](#hacktoberfest-) ![](https://img.shields.io/badge/difficulty-hard-red.svg)
+- [Microsoft Hacktoberfest](#microsoft-hacktoberfest-) ![](https://img.shields.io/badge/difficulty-hard-red.svg)
 - [Mullvad](#mullvad-) ![](https://img.shields.io/badge/difficulty-easy-green.svg)
 - [Netlify](#netlify-) ![](https://img.shields.io/badge/difficulty-easy-green.svg)
 - [npm](#npm-) ![](https://img.shields.io/badge/difficulty-hard-red.svg)
@@ -48,6 +49,10 @@ Sign up at [https://upscri.be/67d2fa](https://upscri.be/67d2fa) to get early acc
 - Make five pull requests in October, earn a limited edition T-shirt! [Reference](https://hacktoberfest.digitalocean.com/)
 
 ![](https://cdn-images-1.medium.com/max/2000/1*9rG8J1r8l-LC0oRvRVoEkA.jpeg)
+
+## Microsoft Hacktoberfest ![](https://img.shields.io/badge/difficulty-hard-red.svg)
+
+- Make one pull request in October 2018 to any [open source Microsoft repository](https://opensource.microsoft.com/), earn a limited edition T-shirt! [Reference](https://open.microsoft.com/2018/09/18/hacktoberfest-2018-microsoft/)
 
 ## Mullvad ![](https://img.shields.io/badge/difficulty-easy-green.svg)
 

--- a/data.json
+++ b/data.json
@@ -42,7 +42,7 @@
   {
     "name": "Microsoft Hacktoberfest",
     "difficulty": "medium",
-    "description": "Make one pull request in October to any open source Microsoft repository, earn a limited edition T-shirt!",
+    "description": "Make one pull request in October 2018 to any <a href='https://opensource.microsoft.com/'>open source Microsoft repository</a>, earn a limited edition T-shirt!",
     "reference": "https://open.microsoft.com/2018/09/30/join-hacktoberfest-2018-celebration-microsoft/",
     "image": "https://images.all-free-download.com/images/graphiclarge/blank_t_shirt_clip_art_19042.jpg",
     "swagType": "T-shirts"

--- a/data.json
+++ b/data.json
@@ -40,6 +40,14 @@
     "swagType": "T-shirts, Stickers"
   },
   {
+    "name": "Microsoft Hacktoberfest",
+    "difficulty": "medium",
+    "description": "Make one pull request in October to any open source Microsoft repository, earn a limited edition T-shirt!",
+    "reference": "https://open.microsoft.com/2018/09/30/join-hacktoberfest-2018-celebration-microsoft/",
+    "image": "https://images.all-free-download.com/images/graphiclarge/blank_t_shirt_clip_art_19042.jpg",
+    "swagType": "T-shirts"
+  },
+  {
     "name": "Mullvad",
     "difficulty": "easy",
     "description": "Send an email to <a href='mailto:support@mullvad.net'>support@mullvad.net</a> with \"STICKERS\" in the subject line. Include a postal address in the email and get an assortment of stickers sent your way.",


### PR DESCRIPTION
2018's Hacktoberfest has the opportunity to gain a T-shirt from Microsoft as well as the normal one from Github / DigitalOcean.

- [x] I've checked that this isn't a duplicate pull request.

Is it regarding a new swag proposal or something else?  
Fill the corresponding section below:

(New Swag Proposal)  
Q. Have you received swag from this?  Not yet, as the event is brand new - but Microsoft should be a pretty reliable source.
Q. How long did it take?  N/A
Q. Does it ship worldwide?  N/A

(Something else)  
Please describe your changes here: 
