### PR TITLE
✨ server side rendering

### DIFF
--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -10,20 +10,9 @@ const webserver     = require('gulp-webserver');
 const concat        = require('gulp-concat');
 const download      = require('gulp-download-stream');
 const responsive    = require('gulp-responsive');
-
-const swagList = () => require('../data.json');
-const escapeName = s => s.replace(/[^a-z0-9]/gi, '_').replace(/_{2,}/g, '_').toLowerCase();
-
-let builtSwagList = null;
-
 const swagList = require('../data.json');
-const tags = Array.from(swagList.reduce(
-    (tagList, {tags}) => {
-        tags.forEach(tag => tagList.add(tag));
-        return tagList;
-    },
-    new Set()
-));
+
+const escapeName = s => s.replace(/[^a-z0-9]/gi, '_').replace(/_{2,}/g, '_').toLowerCase();
 
 gulp.task('webserver', function () {
     return gulp.src('dist')
@@ -34,6 +23,14 @@ gulp.task('webserver', function () {
 });
 
 gulp.task('pug', () => {
+    const tags = Array.from(swagList.reduce(
+        (tagList, { tags }) => {
+            tags.forEach(tag => tagList.add(tag));
+            return tagList;
+        },
+        new Set()
+    ));
+
     return gulp.src('src/pug/*.pug')
         .pipe(pug({
             pretty: true,
@@ -85,7 +82,7 @@ gulp.task('img', () => {
 });
 
 gulp.task('swag-img:download', () => {
-    const downloadList = swagList().map(s => ({
+    const downloadList = swagList.map(s => ({
         url: s.image,
         file: escapeName(s.image) + '.jpg',
     }));
@@ -116,7 +113,7 @@ gulp.task('swag-img:clean', () => {
 });
 
 gulp.task('swag-img:build-data', (cb) => {
-    builtSwagList = swagList().map(s => Object.assign({}, s, {
+    const builtSwagList = swagList.map(s => Object.assign({}, s, {
         image: `/assets/swag-img/${escapeName(s.image)}.jpg`,
     }));
     return mkdirp('dist/assets', () => {

--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -13,6 +13,10 @@ const responsive    = require('gulp-responsive');
 const swagList = require('../data.json');
 
 const escapeName = s => s.replace(/[^a-z0-9]/gi, '_').replace(/_{2,}/g, '_').toLowerCase();
+const builtSwagList = swagList.map(s => Object.assign({}, s, {
+    image: `/assets/swag-img/${escapeName(s.image)}.jpg`,
+}));
+
 
 gulp.task('webserver', function () {
     return gulp.src('dist')
@@ -23,7 +27,7 @@ gulp.task('webserver', function () {
 });
 
 gulp.task('pug', () => {
-    const tags = Array.from(swagList.reduce(
+    const tags = Array.from(builtSwagList.reduce(
         (tagList, { tags }) => {
             tags.forEach(tag => tagList.add(tag));
             return tagList;
@@ -34,7 +38,7 @@ gulp.task('pug', () => {
     return gulp.src('src/pug/*.pug')
         .pipe(pug({
             pretty: true,
-            locals: {swagList, tags}
+            locals: {swagList: builtSwagList, tags}
         }))
         .pipe(gulp.dest('dist/'));
 });
@@ -113,9 +117,6 @@ gulp.task('swag-img:clean', () => {
 });
 
 gulp.task('swag-img:build-data', (cb) => {
-    const builtSwagList = swagList.map(s => Object.assign({}, s, {
-        image: `/assets/swag-img/${escapeName(s.image)}.jpg`,
-    }));
     return mkdirp('dist/assets', () => {
         writeFile('dist/assets/data.json', JSON.stringify(builtSwagList), cb);
     });

--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -16,6 +16,15 @@ const escapeName = s => s.replace(/[^a-z0-9]/gi, '_').replace(/_{2,}/g, '_').toL
 
 let builtSwagList = null;
 
+const swagList = require('../data.json');
+const tags = Array.from(swagList.reduce(
+    (tagList, {tags}) => {
+        tags.forEach(tag => tagList.add(tag));
+        return tagList;
+    },
+    new Set()
+));
+
 gulp.task('webserver', function () {
     return gulp.src('dist')
         .pipe(webserver({
@@ -27,7 +36,8 @@ gulp.task('webserver', function () {
 gulp.task('pug', () => {
     return gulp.src('src/pug/*.pug')
         .pipe(pug({
-            pretty: true
+            pretty: true,
+            locals: {swagList, tags}
         }))
         .pipe(gulp.dest('dist/'));
 });

--- a/site/src/js/index.js
+++ b/site/src/js/index.js
@@ -1,56 +1,25 @@
-const DATA_URL = '/assets/data.json';
-
 /**
  * Initialising global variables
  */
-let swagCache,
-    contentEl    = document.querySelector('#content'),
-    filterInput  = document.querySelector('#filter'),
+let contentEl = document.querySelector('#content'),
+    filterInput = document.querySelector('#filter'),
     sortingInput = document.querySelector('#sorting'),
-    tagsSelect   = document.querySelector('#tags'),
-    firstLoad    = true,
-    selector     = new Selectr('#tags', {
+    firstLoad = true,
+    selector = new Selectr('#tags', {
         multiple: true,
         placeholder: 'Choose tags...',
-        data: {value: '', text: ''}
+        data: window.swagTags.map(tag => ({value: tag, text: tag}))
     });
 
-/**
- * Fetches the JSON swag list. Once it has got the data,
- * it will call the given callback function
- * with one argument: a list of objects.
- */
-const fetchSwag = callback => {
-    let req = new XMLHttpRequest();
-
-    req.onreadystatechange = function() {
-        if (this.readyState === 4 && this.status === 200) {
-            const responseText = req.responseText;
-            const swag = JSON.parse(responseText);
-
-            selector.removeAll();
-            swag.map(item => item.tags.map(tag => selector.add({value: tag, text: tag}, 1)));
-
-            callback(swag);
-        }
-    };
-
-    req.open('GET', DATA_URL, true);
-    req.send();
-};
-
-const renderSwag = swag => {
+const renderSwag = () => {
     UrlHandler();
 
     contentEl.innerHTML = '';
-
-    swagCache = swag;
-
     const filter = getFilter();
     const sorting = getSorting();
     const tagSort = getTagValue();
 
-    swag
+    window.swag
         .filter(v => filter === 'All difficulties' ? true : v.difficulty === filter.toLowerCase())
         .filter(v => tagSort.length ? tagSort.every(val => v.tags.includes(val)) : true)
         .sort((a, b) => {
@@ -95,10 +64,9 @@ const UrlHandler = () => {
             if (searchParams.has('tags')) {
                 selector.setValue(searchParams.get('tags').split(' '));
             }
-            selector.on('selectr.change', attemptRender);
-        }
-        else {
-            if (getTagValue().length){
+            selector.on('selectr.change', renderSwag);
+        } else {
+            if (getTagValue().length) {
                 searchParams.set('tags', getTagValue().join(' '));
                 const newRelativePathQuery = `${window.location.pathname}?${searchParams.toString()}`;
                 history.pushState(null, '', newRelativePathQuery);
@@ -109,11 +77,9 @@ const UrlHandler = () => {
     }
 };
 
-const attemptRender = () => swagCache === undefined ? fetchSwag(renderSwag) : renderSwag(swagCache);
-
 window.addEventListener('load', () => {
-    attemptRender();
+    UrlHandler();
 
-    filterInput.addEventListener('input', attemptRender);
-    sortingInput.addEventListener('input', attemptRender);
+    filterInput.addEventListener('input', renderSwag);
+    sortingInput.addEventListener('input', renderSwag);
 });

--- a/site/src/pug/includes/body.pug
+++ b/site/src/pug/includes/body.pug
@@ -32,6 +32,20 @@ include ./fork.pug
                     select#tags
 
         .content.flex#content
+            - let difficulty;
+            each swag in swagList
+                - difficulty = swag.difficulty + ' difficulty';
+                div.item
+                    div.title.flex
+                        h1=swag.name
+                        div(class=difficulty title=difficulty)
+                    p.swag
+                        each swagTag in swag.tags
+                            span!=swagTag
+                    div.flex.img-container
+                        img(src=swag.image)
+                    p.description!=swag.description
+                    a(href=swag.reference) Check it out
 
     footer.flex
         .item.flex
@@ -42,5 +56,8 @@ include ./fork.pug
             p Designed by #[a(href="https://github.com/zac-garby") Zac Garby] and #[a(href="https://mihir.ch/") Mihir Chaturvedi]
         .item.flex
             p Want to be listed? #[a(href="https://github.com/swapagarwal/swag-for-dev/issues/new") Contact us].
-
     #codefund_ad
+
+    script(defer).
+        window.swag = !{JSON.stringify(swagList)};
+        window.swagTags = !{JSON.stringify(tags)};


### PR DESCRIPTION
- [x] I've checked that this isn't a duplicate pull request.

Please describe your changes here: 
 - Prerender swag to prevent content flashing (refs #64, may or may not close it)
 - Load swag as JSON at bottom of file (removes need for additional HTTP request)
	- This is really tiny (2.2k) so it should have a minimal impact on load times

Todo (not in this PR)

 - [ ] filter: toggle visibility based on classes to reduce re-rendering requirement
 - [ ] sort: Clone DOM nodes rather than use template literals. This is to DRY up and possibly get performance improvements
 - [ ] Disallow sorting by difficulty when only one difficulty is shown