### PR TITLE
Change link to devswag.io to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Sign up at [https://upscri.be/67d2fa](https://upscri.be/67d2fa) to get early acc
 
 ## Contents
 
-All swag opportunities can be found at [http://devswag.io/](http://devswag.io/) 😎
+All swag opportunities can be found at [https://devswag.io/](https://devswag.io/) 😎
 
 ## Contributing
 


### PR DESCRIPTION
- [x] I've checked that this isn't a duplicate pull request.

(Something else)  
Please describe your changes here: 

Changes link in readme to https because it is nicer to offer a https domain than a http domain and it's already redirecting from http to https