### PR TITLE
fix(lint): no-undef error: allow Selectr global var

### DIFF
--- a/site/src/js/index.js
+++ b/site/src/js/index.js
@@ -1,3 +1,4 @@
+/* global Selectr */
 /**
  * Initialising global variables
  */


### PR DESCRIPTION
Fixes lint

```
$ npm run lint

> swag-for-dev@1.0.0 lint /home/zadkiel/work/swag-for-dev/site
> eslint *.js src/js/*.js


/home/zadkiel/work/swag-for-dev/site/src/js/index.js
  8:20  error  'Selectr' is not defined  no-undef

✖ 1 problem (1 error, 0 warnings)
```