### PR TITLE
Fixes gulp default task. #118

### DIFF
--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -160,4 +160,4 @@ gulp.task('build', gulp.series(
     )
 ));
 
-gulp.task('default', gulp.parallel('webserver', 'build', 'watch'));
+gulp.task('default', gulp.series('build', 'webserver', 'watch'));


### PR DESCRIPTION
Steps to reproduce the issue (as per README):
1. Fresh clone.
2. `cd site`
3. `npm install`
4. `gulp`

The above leads to an error `Error: File not found with singular glob: ~/swag-for-dev/site/dist`.

This is most probably because gulp starts the webserver before the files are built since the tasks are in parallel. Apart from this, even if `gulp build` is run before `gulp`, it displays a blank page on localhost:8000, until manually refreshed.

Changing gulp default in the series `build --> webserver --> watch` fixed the issue.