### PR TITLE
Multiple issue & pull-request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,12 +1,9 @@
+<!-- Prefer using a these templates if there is one that fits: https://github.com/swapagarwal/swag-for-dev/issues/new/choose -->
+
 - [ ] I've checked that this isn't a duplicate issue.
 
-Is it regarding the current promotions or something new?
-Fill the corresponding section below:
+<!-- Describe your concern below -->
 
-(Current Promotion)
-Please describe your concern here:
 
-(New Promotion)
-Reference Link:
-- [ ] I've confirmed that the promotion is legit.
-- [ ] I've verified that it's still available to the public.
+
+<!-- Thanks for contributing! -->

--- a/.github/ISSUE_TEMPLATE/----new-swag-opportunity.md
+++ b/.github/ISSUE_TEMPLATE/----new-swag-opportunity.md
@@ -10,7 +10,7 @@ about: Use this template to propose a new swag opportunity
 Q. Which company offers it?  
 A. : 
 
-Q. Where have you seen the anouncement (URL)?  
+Q. Where have you seen the announcement (URL)?  
 A. : 
 
 Q. What kind of swag (clothing, stickers, ...)?  

--- a/.github/ISSUE_TEMPLATE/----new-swag-opportunity.md
+++ b/.github/ISSUE_TEMPLATE/----new-swag-opportunity.md
@@ -1,0 +1,34 @@
+---
+name: "\U00002728 Add a new swag opportunity"
+about: Use this template to propose a new swag opportunity
+---
+
+## Wild swag opportunity appeared!
+
+- [ ] I've checked that this isn't a duplicate issue.
+
+Q. Which company offers it?  
+A. : 
+
+Q. Where have you seen the anouncement (URL)?  
+A. : 
+
+Q. What kind of swag (clothing, stickers, ...)?  
+A. : 
+
+Q. Have you received swag from this?  
+A. : 
+
+Q. How long did it take?  
+A. : 
+
+Q. Does it ship worldwide?  
+A. : 
+
+<!-- Anything to add? -->
+
+
+- [ ] I've checked that the promotion is legit.
+- [ ] I've checked that it's still available to the public.
+
+<!-- Thanks for your contribution! -->

--- a/.github/ISSUE_TEMPLATE/---issue-swag-opportunity.md
+++ b/.github/ISSUE_TEMPLATE/---issue-swag-opportunity.md
@@ -1,0 +1,17 @@
+---
+name: "\U0001F41B Issue with a swag opportunity"
+about: Use this template to raise a concern regarding an existing swag opportunity
+---
+
+## Issue with an existing swag opportunity
+
+- [ ] I've checked that this isn't a duplicate issue.
+
+Q. Which opportunity?  
+A. : 
+
+<!-- Describe your concern below -->
+
+
+
+<!-- Thanks for your contribution! -->

--- a/.github/ISSUE_TEMPLATE/---issue-website.md
+++ b/.github/ISSUE_TEMPLATE/---issue-website.md
@@ -1,0 +1,14 @@
+---
+name: "\U0001F41B Issue regarding the website"
+about: Use this template to raise a concern or propose a new feature regarding the website
+---
+
+## Issue regarding the website
+
+- [ ] I've checked that this isn't a duplicate issue.
+
+<!-- Describe your concern below -->
+
+
+
+<!-- Thanks for your contribution! -->

--- a/.github/ISSUE_TEMPLATE/--anything-else.md
+++ b/.github/ISSUE_TEMPLATE/--anything-else.md
@@ -1,0 +1,12 @@
+---
+name: "\U0001F4A1 Anything else"
+about: Use this template for any other concern that doesn't fits elsewhere
+---
+
+- [ ] I've checked that this isn't a duplicate issue.
+
+<!-- Describe your concern below -->
+
+
+
+<!-- Thanks for your contribution! -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,13 @@
+<!--
+If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
+https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
+-->
+
+- [ ] I've checked that this isn't a new swag opportunity proposal.
 - [ ] I've checked that this isn't a duplicate pull request.
 
-Is it regarding a new swag proposal or something else?  
-Fill the corresponding section below:
+<!-- Describe your changes below -->
 
-(New Swag Proposal)
 
-* Company:
-* Reference URL: 
 
-Q. Have you received swag from this?  
-Q. How long did it take?  
-Q. Does it ship worldwide?  
-
-(Something else)  
-Please describe your changes here: 
+<!-- Thanks for contributing! -->

--- a/.github/PULL_REQUEST_TEMPLATE/new-swag-opportunity.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new-swag-opportunity.md
@@ -1,0 +1,10 @@
+## Wild swag opportunity appeared!
+
+- [ ] I've checked that this isn't a duplicate pull request.
+- [ ] I've checked that this is linked to an new swag opportunity issue <!>
+
+Implement swag opportunity: <swag-name>
+
+Closes #<swag-issue>
+
+<!-- Thank you for contributing! -->


### PR DESCRIPTION
- [x] I've checked that this isn't a duplicate pull request.

I just discovered we are able to use multiples issue and pull-request templates, the UI will just ask you wich one you want to use.
Example: https://github.com/aslafy-z/swag-for-dev/issues => New issue goes to https://github.com/aslafy-z/swag-for-dev/issues/new/choose

Github reference: 
https://blog.github.com/2018-01-25-multiple-issue-and-pull-request-templates/

**Edit**: It doesn't works pretty well with pull-requests: There is no UI to select which template to use. Alternatively, we could add a link to the readme who points to this: https://github.com/aslafy-z/swag-for-dev/compare/master...aslafy-z:add-hasura?expand=1&template=new-swag-opportunity.md 