### PR TITLE
Adding Passenger swag

### DIFF
--- a/data.json
+++ b/data.json
@@ -104,6 +104,14 @@
     "tags": ["clothing", "hacktoberfest", "stickers"]
   },
   {
+    "name": "Passenger",
+    "difficulty": "easy",
+    "description": "Register to join the November 1st livestream in which Phusion adds a major feature to Passenger, and win a custom key cap or beanie with the Passenger logo embroided (and stickers, guaranteed).",
+    "reference": "https://blog.phusion.nl/2018/10/19/livestreaming-from-phusion-hq-adding-a-feature-to-passenger/",
+    "image": "https://www.phusion.nl/images/beanie.png",
+    "tags": ["clothing", "accessories", "stickers"]
+  },
+  {
     "name": "SendGrid",
     "difficulty": "hard",
     "description": "Five accepted pull results from SendGrid will qualify you for a special edition SendGrid Hacktoberfest T-shirt.",


### PR DESCRIPTION
- [x] I've checked that this isn't a duplicate pull request.

Is it regarding a new swag proposal or something else?  
Fill the corresponding section below:

New Swag Proposal

* Company: Phusion B.V.
* Reference URL: https://blog.phusion.nl/2018/10/19/livestreaming-from-phusion-hq-adding-a-feature-to-passenger/

Q. Have you received swag from this?  no
Q. How long did it take?  
Q. Does it ship worldwide? yes 

Please describe your changes here: 
Adding Passenger swag devs registering for its November 1st livestream are eligable to win.