### PR TITLE
HOTFIX: Filter out hacktoberfest data

### DIFF
--- a/site/get-data.js
+++ b/site/get-data.js
@@ -2,7 +2,7 @@ const swagImages = [];
 const fileNames = [];
 const swagList = require('../data.json').map(swag => {
     // @todo: remove once `active: Boolean` is added to data.json
-    if (swag.tags.includes('hacktoberfest') {
+    if (swag.tags.includes('hacktoberfest')) {
         return false;
     }
     // Generate unique filename

--- a/site/get-data.js
+++ b/site/get-data.js
@@ -1,6 +1,9 @@
 const swagImages = [];
 const fileNames = [];
 const swagList = require('../data.json').map(swag => {
+    if (swag.tags.includes('hacktoberfest') {
+        return false;
+    }
     // Generate unique filename
     // @todo: do we want to force jpeg as the image format?
     // const extension = swag.image.split('.').pop();
@@ -25,6 +28,6 @@ const swagList = require('../data.json').map(swag => {
     fileNames.push(fileName);
 
     return swag;
-});
+}).filter(Boolean);
 
 module.exports = { swagList, swagImages };

--- a/site/get-data.js
+++ b/site/get-data.js
@@ -1,6 +1,7 @@
 const swagImages = [];
 const fileNames = [];
 const swagList = require('../data.json').map(swag => {
+    // @todo: remove once `active: Boolean` is added to data.json
     if (swag.tags.includes('hacktoberfest') {
         return false;
     }
@@ -28,6 +29,7 @@ const swagList = require('../data.json').map(swag => {
     fileNames.push(fileName);
 
     return swag;
+// @todo: remove (if needed) once `active: Boolean` is added to data.json
 }).filter(Boolean);
 
 module.exports = { swagList, swagImages };


### PR DESCRIPTION
As we don't have support for client-side filtering based on swag state, this is a hotfix to disable all hacktoberfest-related swag from being shown. Once we add the state filtering, this can be removed
