### PR TITLE
Remove 'position: relative' from default CSS

### DIFF
--- a/src/styl/imports/universal.styl
+++ b/src/styl/imports/universal.styl
@@ -1,10 +1,8 @@
 *
 	padding 0
 	margin 0
-	position relative
 	box-sizing border-box
 	text-rendering optimizeLegibility
-
 
 *.flex
 	display flex
@@ -28,3 +26,4 @@
 	width 100%
 	height 100%
 	justify-content center
+	position relative

--- a/src/styl/index.styl
+++ b/src/styl/index.styl
@@ -43,6 +43,9 @@ section.main
         .item
             padding 5px
 
+        .select-wrapper
+            position relative
+
         .select-wrapper:before
             content '▼'
             position absolute


### PR DESCRIPTION
- [x] I've checked that this isn't a duplicate pull request.

It was breaking tools like Google's [`VisBug`](https://github.com/GoogleChromeLabs/ProjectVisBug)

![a](https://user-images.githubusercontent.com/8191198/48498718-14866f00-e837-11e8-9339-c083994b16a9.png)

I reapplied the property to elements that needs it. I may have missed some, tell me and I fix it.