### PR TITLE
Fix swag items that aren't related to hacktoberfest

### DIFF
--- a/data.json
+++ b/data.json
@@ -77,7 +77,7 @@
     "description": "Everyone who gets 1 PR accepted to a Kong repo can get a Kong Contributor T-shirt!",
     "reference": "https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributor-t-shirt",
     "image": "https://konghq.com/wp-content/uploads/2018/04/100-contributor-t-shirt-1024x768.jpg",
-    "tags": ["clothing", "hacktoberfest"]
+    "tags": ["clothing"]
   },
   {
     "name": "LBRY",
@@ -189,7 +189,7 @@
     "description": "Complete the first set of objectives in <a href='https://twilio.com/quest'>Twilio Quest</a> and get a Twilio Quest t-shirt right to your door.",
     "reference": "https://www.youtube.com/watch?v=r9MPBJjPQdA",
     "image": "https://pbs.twimg.com/media/DpB5PIYVAAAX4eC.jpg",
-    "tags": ["clothing", "hacktoberfest"]
+    "tags": ["clothing"]
   },
   {
     "name": "Umbraco",


### PR DESCRIPTION
- [x] I've checked that this isn't a duplicate pull request.

Delete `hacktoberfest` tag from swag items that aren't linked to it.

- Kong
- Twilio Quest