### PR TITLE
Fix Google Assistant promo image

### DIFF
--- a/data.json
+++ b/data.json
@@ -60,7 +60,7 @@
     "difficulty": "hard",
     "description": "Make an app for the Google Assistant available to users, get an exclusive Google Assistant t-shirt and a Google Home (if a certain number of users engage with it)!",
     "reference": "https://developers.google.com/actions/community/overview",
-    "image": "https://i2.wp.com/radthemaker.com/wp-content/uploads/2017/11/My-Google-Assistant-T-Shirt.jpg",
+    "image": "https://cdn-images-1.medium.com/max/1200/1*IXenex7A6f39Y2m4ch3oiw.jpeg",
     "tags": ["clothing", "device"]
   },
   {


### PR DESCRIPTION
- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

I've replaced the current Google Assistant promo image, which returns a 400 error when fetched, with a different image from [this article](https://medium.com/@amdcaruso/my-first-step-with-the-google-assistant-ab4c5ba04176).