### PR TITLE
Blocking: Update Google Assistant swag image

### DIFF
--- a/data.json
+++ b/data.json
@@ -60,7 +60,7 @@
     "difficulty": "hard",
     "description": "Make an app for the Google Assistant available to users, get an exclusive Google Assistant t-shirt and a Google Home (if a certain number of users engage with it)!",
     "reference": "https://developers.google.com/actions/community/overview",
-    "image": "https://i2.wp.com/radthemaker.com/wp-content/uploads/2017/11/My-Google-Assistant-T-Shirt.jpg",
+    "image": "https://i.imgur.com/xElC8jm.jpg",
     "tags": ["clothing", "device"]
   },
   {


### PR DESCRIPTION
<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [x] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->

Update Google Assistant swag image as the current URL is dead. See here: https://app.netlify.com/sites/peaceful-chandrasekhar-efde8e/deploys/5bf6cd8505c417658a06b1b7 

New image is coming from http://niwasawa.hatenablog.jp/entry/20180509/google-assistant-t-shirt, thanks to @niwasawa. I changed it because it shows better the t-shirt color. (Original is here to compare: https://devswag.io/assets/swag-img/google_assistant-0880ffbe3b.jpg)

This blocks builds so it needs to be merged fast <!>

Ref #169 

<!-- Thanks for contributing! -->
