### PR TITLE
Tweak lint: force spaces between brakets

### DIFF
--- a/site/.eslintrc
+++ b/site/.eslintrc
@@ -26,6 +26,10 @@
       "error",
       "always"
     ],
-    "no-console": 0
+    "no-console": 0,
+    "object-curly-spacing": [
+      "error",
+      "always"
+    ]
   }
 }


### PR DESCRIPTION
- [x] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->

Enable eslint `object-curly-spacing` rule to force having spaces between object curly braces.

This is a suggestion, I opened this to discuss the subject.  


<!-- Thanks for contributing! -->
