### PR TITLE
Fix: Update HSTS policies to match listing requirements

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -18,7 +18,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     X-XSS-Protection = "1; mode=block"
     Feature-Policy = "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'"
-    Strict-Transport-Security = "max-age=15552000; preload"
+    Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"
     X-Content-Type-Options = "nosniff"
 
 [[headers]]


### PR DESCRIPTION
This PR fixes some issues who prevent to be listed in the [hstspreload list](https://hstspreload.org):

- Error: No includeSubDomains directive
  The header must contain the `includeSubDomains` directive.
- Error: Max-age too low
  The max-age must be at least 31536000 seconds (≈ 1 year), but the header currently only has max-age=15552000.

See here: https://hstspreload.org/?domain=devswag.io

