### PR TITLE
Fix/js deps to body

### DIFF
--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -10,6 +10,6 @@ html(lang='en')
 
 		include ./includes/body.pug
 
-	script(src='https://unpkg.com/mobius1-selectr@2.4.4/dist/selectr.min.js')
+	    script(src='https://unpkg.com/mobius1-selectr@2.4.4/dist/selectr.min.js')
 
-	script(defer src=bustedAssets.js)
+	    script(defer src=bustedAssets.js)

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -10,6 +10,6 @@ html(lang='en')
 
 		include ./includes/body.pug
 
-	    script(src='https://unpkg.com/mobius1-selectr@2.4.4/dist/selectr.min.js')
+		script(src='https://unpkg.com/mobius1-selectr@2.4.4/dist/selectr.min.js')
 
-	    script(defer src=bustedAssets.js)
+		script(defer src=bustedAssets.js)


### PR DESCRIPTION
<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->

From [https://devswag.io](https://devswag.io): Line 134

```
</body><script src="https://unpkg.com/mobius1-selectr@2.4.4/dist/selectr.min.js"></script><script defer='defer' src='https://d33wubrfki0l68.cloudfront.net/js/b81343513a8edc4d23853dd8f7fcb6d0f6114c8c/assets/js/index-087cc6a5d5.js'></script></html>
```

These scripts have to be within the body section. Moving them back in it.

<!-- Thanks for contributing! -->
