### PR TITLE
Use jsDeliver instead of unpkg as CDN provider

### DIFF
--- a/src/pug/includes/head.pug
+++ b/src/pug/includes/head.pug
@@ -14,7 +14,7 @@ link(rel="apple-touch-icon" size="128x128" href="/assets/img/logo.png")
 link(rel="stylesheet" href=bustedAssets.css)
 link(rel="stylesheet" href="https://fonts.googleapis.com/css?family=Cabin")
 
-link(rel='stylesheet' href='https://unpkg.com/mobius1-selectr@2.4.4/dist/selectr.min.css')
+link(rel='stylesheet' href='https://cdn.jsdelivr.net/npm/mobius1-selectr@2.4.8/dist/selectr.min.css')
 
 noscript
     style.

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -10,6 +10,6 @@ html(lang='en')
 
 		include ./includes/body.pug
 
-		script(src='https://unpkg.com/mobius1-selectr@2.4.8/dist/selectr.min.js')
+		script(src='https://cdn.jsdelivr.net/npm/mobius1-selectr@2.4.8/dist/selectr.min.js')
 
 		script(defer src=bustedAssets.js)


### PR DESCRIPTION
<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->

Unpkg CDN is slower than jsDeliver, see https://www.cdnperf.com/

They also have a uge [sponsors list](https://www.jsdelivr.com/sponsors) compared to [unpkg one](https://unpkg.com/#/about)




<!-- Thanks for contributing! -->
