### PR TITLE
Codeship had increased their Build count to the 15 successful builds …

### DIFF
--- a/data.json
+++ b/data.json
@@ -38,7 +38,7 @@
   {
     "name": "Codeship",
     "difficulty": "medium",
-    "description": "Submit 5 builds in 30 days, get t-shirts & stickers sent your way!",
+    "description": "Submit 15 builds in 30 days, get t-shirts & stickers sent your way!",
     "reference": "https://codeship.com/swag",
     "image": "https://juliesfreebies.com/wp-content/uploads/2016/05/codeship-swag.jpg",
     "dateAdded": "2018-02-18T18:44:53.000Z",


### PR DESCRIPTION

![47384396_2198066183549319_9061124424568143872_n](https://user-images.githubusercontent.com/27560724/50397396-365c0580-0796-11e9-9fb3-8b603ce0f076.jpg)


Codeship has changed their requirement to receive swag to 15 Builds in 30 days. In this image I'm showcasing what I received from the Codeship.  

<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->



<!-- Thanks for contributing! -->
