### PR TITLE
Fix source{d} promo image

### DIFF
--- a/data.json
+++ b/data.json
@@ -211,7 +211,7 @@
     "difficulty": "hard",
     "description": "Three merged pull requests in any source{d} repo to receive a limited edition T-shirt as well as one sticker for those who get at least one pull requests merged.",
     "reference": "https://go.sourced.tech/hacktoberfest",
-    "image": "https://pbs.twimg.com/profile_images/685466276907642881/TGox2e02_400x400.png",
+    "image": "https://pbs.twimg.com/media/DrA_3NBVYAAmHnS.jpg",
     "dateAdded": "2018-10-23T10:00:46.000Z",
     "tags": ["clothing", "hacktoberfest", "stickers"]
   },


### PR DESCRIPTION
- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

This fixes the image of the source{d} promo. This should be merged ASAP as it's blocking development for #159.