### PR TITLE
Set default text color to black

### DIFF
--- a/src/styl/imports/base.styl
+++ b/src/styl/imports/base.styl
@@ -22,7 +22,6 @@ html, body, :root
 	-webkit-font-smoothing antialiased
 	-moz-osx-font-smoothing grayscale
 	-webkit-overflow-scrolling touch
-	color #000
 
 code
 	padding 1px 5px

--- a/src/styl/imports/base.styl
+++ b/src/styl/imports/base.styl
@@ -22,6 +22,7 @@ html, body, :root
 	-webkit-font-smoothing antialiased
 	-moz-osx-font-smoothing grayscale
 	-webkit-overflow-scrolling touch
+	color #000
 
 code
 	padding 1px 5px

--- a/src/styl/index.styl
+++ b/src/styl/index.styl
@@ -77,6 +77,7 @@ section.main
 			font-family $default-font-family
 			font-size 0.9rem
 			cursor pointer
+			color #000
 
 		@import "imports/selectr-theme"
 


### PR DESCRIPTION
<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->

Here's how the select renders in Firefox:

![](https://screenshotscdn.firefoxusercontent.com/images/8290c3bc-e13c-46f0-be39-d265f01949df.png)

Applied a patch to set default text color to black (#000). 

<!-- Thanks for contributing! -->
