### PR TITLE
Alexa swag campaign is no longer active

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,14 +1,5 @@
 [
   {
-    "name": "Alexa",
-    "difficulty": "hard",
-    "description": "Publish a skill, get a t-shirt and an Echo Spot (if 50 customers per month use your Display skill for the first three months after publication)! Earn a 2-pack of Echo Buttons if you publish a Gadgets skill!",
-    "reference": "https://developer.amazon.com/alexa-skills-kit/alexa-developer-skill-promotion",
-    "image": "https://m.media-amazon.com/images/G/01/mobile-apps/dex/alexa/alexa-skills-kit/promos/ASK_DevIncentive_swag_v2._CB472624419_.png",
-    "dateAdded": "2018-02-18T06:03:00.000Z",
-    "tags": ["clothing", "device"]
-  },
-  {
     "name": "Alligator.io",
     "difficulty": "hard",
     "description": "Write a blog post on frontend development topics, get some cool Alligator stickers!",


### PR DESCRIPTION
- [X] I've checked that this isn't a new swag opportunity proposal.
- [X] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->
Alexa campaign expired on 31 Dec 2018. Explained here: Explained here: https://developer.amazon.com/alexa-skills-kit/alexa-developer-skill-promotion


<!-- Thanks for contributing! -->
