### PR TITLE
Fix redirect when the `search` param is `false`

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -117,7 +117,7 @@ window.addEventListener('load', () => {
 			selectr.setValue(search.get('tags').split(' '));
 		}
 
-		showExpired.checked = Boolean(search.get('expired'));
+		showExpired.checked = search.get('expired') === 'true';
 	}
 
 	selectr.on('selectr.change', cascade);


### PR DESCRIPTION
- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

This fixes an issue where the `expired` query parameter is changed from `false` to `true`.

See more on this in #159 and https://github.com/swapagarwal/swag-for-dev/pull/159#issuecomment-457642144.

// cc @aslafy-z @vikaspotluri123