### PR TITLE
Hide expired promos on initial load

### DIFF
--- a/src/pug/includes/body.pug
+++ b/src/pug/includes/body.pug
@@ -43,7 +43,7 @@ include ./fork.pug
 				- difficulty = swag.difficulty + ' difficulty';
 				- difficultyTitle = 'Difficulty: ' + swag.difficulty;
 				div(
-					class="item visible " + swag.difficulty + swag.tags.map(t => ` tag-${t}`).join('')
+					class="item " + swag.difficulty + swag.tags.map(t => ` tag-${t}`).join('')
 					data-name=swag.name.toLowerCase()
 					data-difficulty=['easy','medium', 'hard'].indexOf(swag.difficulty)
 				)

--- a/src/pug/includes/body.pug
+++ b/src/pug/includes/body.pug
@@ -44,7 +44,7 @@ include ./fork.pug
 				- difficultyTitle = 'Difficulty: ' + swag.difficulty;
 				- expired = swag.tags.includes('expired');
 				div(
-					class="item " + (!expired ? 'visible ' : '') + swag.difficulty + swag.tags.map(t => ` tag-${t}`).join('')
+					class="item " + (expired ? '' : 'visible ') + swag.difficulty + swag.tags.map(t => ` tag-${t}`).join('')
 					data-name=swag.name.toLowerCase()
 					data-difficulty=['easy','medium', 'hard'].indexOf(swag.difficulty)
 				)

--- a/src/pug/includes/body.pug
+++ b/src/pug/includes/body.pug
@@ -42,8 +42,9 @@ include ./fork.pug
 			each swag in swagList
 				- difficulty = swag.difficulty + ' difficulty';
 				- difficultyTitle = 'Difficulty: ' + swag.difficulty;
+				- expired = swag.tags.includes('expired');
 				div(
-					class="item " + swag.difficulty + swag.tags.map(t => ` tag-${t}`).join('')
+					class="item " + (!expired ? 'visible ' : '') + swag.difficulty + swag.tags.map(t => ` tag-${t}`).join('')
 					data-name=swag.name.toLowerCase()
 					data-difficulty=['easy','medium', 'hard'].indexOf(swag.difficulty)
 				)


### PR DESCRIPTION
- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

This makes sure the expired promos are hidden when loading the website for the first time by hiding all promos by default, and then showing the valid promos using JS.
Note that I tried to do this by using a conditional expression in Pug where the promo gets the `"visible"` class if `swag.expired === false`, but it didn't work for some reason (probably because I don't know how to use Pug).

See more on this in #159 and https://github.com/swapagarwal/swag-for-dev/pull/159#issuecomment-457642144.

// cc @aslafy-z @vikaspotluri123