### PR TITLE
Remove Google Assistant Swag

### DIFF
--- a/data.json
+++ b/data.json
@@ -99,15 +99,6 @@
     "tags": ["clothing", "stickers"]
   },
   {
-    "name": "Google Assistant",
-    "difficulty": "hard",
-    "description": "Make an app for the Google Assistant available to users, get an exclusive Google Assistant t-shirt and a Google Home (if a certain number of users engage with it)!",
-    "reference": "https://developers.google.com/actions/community/overview",
-    "image": "https://i.imgur.com/xElC8jm.jpg",
-    "dateAdded": "2018-02-18T19:59:42.000Z",
-    "tags": ["clothing", "device"]
-  },
-  {
     "name": "Hasura",
     "difficulty": "medium",
     "description": "Submit a PR to Hasura's <a href='https://github.com/hasura/graphql-engine'>GraphQL Engine repo</a> in October 2018 and get a Hasura sticker pack. If your PR to an issue tagged as 'hacktoberfest' gets merged, you also get a Hasura t-shirt!",


### PR DESCRIPTION
Removed the Google Assistant swag as it is paused

Fixes #330

<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->



<!-- Thanks for contributing! -->
