### PR TITLE
set default sorting to newest first

### DIFF
--- a/src/pug/includes/body.pug
+++ b/src/pug/includes/body.pug
@@ -28,7 +28,7 @@ include ./fork.pug
 							option(value="ALPHABETICAL_DESCENDING" class="alphabetical") Alphabetical, reversed
 							option(value="DIFFICULTY_ASCENDING" class="difficulty") Difficulty
 							option(value="DIFFICULTY_DESCENDING" class="difficulty") Difficulty, reversed
-							option(value="DATEADDED_DESCENDING" class="dateAdded") Newest first
+							option(value="DATEADDED_DESCENDING" class="dateAdded" selected=true) Newest first
 							option(value="DATEADDED_ASCENDING" class="dateAdded") Oldest first
 					span order
 


### PR DESCRIPTION
<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [x] I've checked that this isn't a new swag opportunity proposal.
- [ ] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->
Set selected value to true for `Newest First` option so that "Newest First" is selected on page load. Kept current list order in place. Please advise if something else is needed.

This refers to #338
<!-- Thanks for contributing! -->
