### PR TITLE
Update Hasura's swag for Hacktoberfest 2019

### DIFF
--- a/data.json
+++ b/data.json
@@ -119,11 +119,11 @@
   {
     "name": "Hasura",
     "difficulty": "medium",
-    "description": "Submit a PR to Hasura's <a href='https://github.com/hasura/graphql-engine'>GraphQL Engine repo</a> in October 2018 and get a Hasura sticker pack. If your PR to an issue tagged as 'hacktoberfest' gets merged, you also get a Hasura t-shirt!",
-    "reference": "https://blog.hasura.io/announcing-hacktoberfest-2018-with-hasura-621045dc9560",
+    "description": "Submit a PR to Hasura's <a href='https://github.com/hasura/graphql-engine'>GraphQL Engine</a> or <a href='https://github.com/hasura/learn-graphql'>GraphQL Tuturial Series</a> during Hacktoberfest 2019 and get a Hasura sticker pack. If your PR gets merged, you also get a Hasura t-shirt!",
+    "reference": "https://blog.hasura.io/hasura-joins-hacktoberfest-2019/",
     "image": "https://cdn-images-1.medium.com/max/1600/1*kQxL8yhs0c1x1WVXnjhrIw.png",
-    "dateAdded": "2018-10-12T13:25:10.000Z",
-    "tags": ["clothing", "hacktoberfest", "expired", "stickers"]
+    "dateAdded": "2019-10-02T21:06:00.000Z",
+    "tags": ["clothing", "hacktoberfest", "stickers"]
   },
   {
     "name": "IPFS",


### PR DESCRIPTION
Addresses #314

<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->

This PR addresses #314, it updates the expired Hasura's swag from last year, and updates the description and reference for Hasura Hacktoberfest 2019 challenge.

I kept the image because t-shirt and stickers designs are not ready yet.

<!-- Thanks for contributing! -->
