### PR TITLE
Fix Travis build -> Hacktoberfest 2019 image URL

### DIFF
--- a/data.json
+++ b/data.json
@@ -112,7 +112,7 @@
     "difficulty": "hard",
     "description": "To qualify for the official limited edition Hacktoberfest T-shirt, you must register and then make four pull requests (PRs) between October 1-31 (in any time zone).",
     "reference": "https://hacktoberfest.digitalocean.com/" ,
-    "image": "https://pbs.twimg.com/card_img/1176869054440759297/fqTgIxE3?format=png&name=medium",
+    "image": "https://hacktoberfest.digitalocean.com/assets/HF19_social-744d976f227e4aff6866443abcede8c651b309ec9c7c9f7410f5944f8e1299b9.png",
     "dateAdded": "2019-09-25T17:27:00.000Z",
     "tags": ["clothing", "hacktoberfest"]
   },


### PR DESCRIPTION
<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [X] I've checked that this isn't a new swag opportunity proposal.
- [X] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->
This PR fixes the Travis Build error, the current Hacktoberfest 2019 image urls isn't valid anymore.


<!-- Thanks for contributing! -->
