### PR TITLE
Fix responsive sizing for difficulty tag

### DIFF
--- a/src/pug/includes/body.pug
+++ b/src/pug/includes/body.pug
@@ -53,7 +53,8 @@ include ./fork.pug
 				)
 					div.title.flex
 						h1=swag.name
-						div(class=difficulty title=difficultyTitle)
+						div
+							div(class=difficulty title=difficultyTitle)
 							span.sr-only=difficultyTitle
 					p.swag
 						each swagTag in swag.tags

--- a/src/pug/includes/body.pug
+++ b/src/pug/includes/body.pug
@@ -55,7 +55,7 @@ include ./fork.pug
 						h1=swag.name
 						div
 							div(class=difficulty title=difficultyTitle)
-							span.sr-only=difficultyTitle
+								span.sr-only=difficultyTitle
 					p.swag
 						each swagTag in swag.tags
 							span!=swagTag

--- a/src/styl/imports/card.styl
+++ b/src/styl/imports/card.styl
@@ -15,8 +15,8 @@
 			font-size 2rem
 
 		.difficulty
-			height 30px
-			width 30px
+			height 2rem
+			width 2rem
 			border-radius 50%
 			border 2px solid black
 


### PR DESCRIPTION
- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->
## Description
Per issue #393, the difficulty label distorts at low screen width sizes.

## How to test
Run the project and resize the window to the desired screen size to confirm consistent behavior.

## Screenshot
[![Image of responsive change, resolution 282 x 648](https://i.gyazo.com/a347803da3a5be45633103b47d413a19.png)](https://gyazo.com/a347803da3a5be45633103b47d413a19)


<!-- Thanks for contributing! -->
