### PR TITLE
Fixed border on swag images

### DIFF
--- a/data.json
+++ b/data.json
@@ -135,6 +135,15 @@
     "tags": ["clothing", "stickers"]
   },
   {
+    "name": "Globo",
+    "difficulty": "medium",
+    "description": "Contribute 2 pull requests to Globo's Open Source Projects. At least 1 PR has to be accepted and you have to be in the first 200 registrants to get an exclusive t-shirt. Delivery only in Brazil.",
+    "reference": "https://opensource.globo.com/hacktoberfest/",
+    "image": "https://opensource.globo.com/static/hacktoberfest-lg-ccb42ae80e9ac29693f57e549263e889.png",
+    "dateAdded": "2019-10-10T13:00:00.000Z",
+    "tags": ["hacktoberfest", "clothing"]
+  },
+  {
     "name": "Google Assistant",
     "difficulty": "hard",
     "description": "Make an app for the Google Assistant available to users, get an exclusive Google Assistant t-shirt and a Google Home (if a certain number of users engage with it)!",

--- a/src/pug/includes/body.pug
+++ b/src/pug/includes/body.pug
@@ -60,7 +60,7 @@ include ./fork.pug
 						each swagTag in swag.tags
 							span!=swagTag
 					div.flex.img-container
-						a(href=swag.reference target="_blank").image-link
+						a(href=swag.reference target="_blank")
 							picture
 								source(type="image/webp" srcset=swag.images.webp)
 								source(type="image/jpeg" srcset=swag.images.jpeg)

--- a/src/pug/includes/body.pug
+++ b/src/pug/includes/body.pug
@@ -60,13 +60,13 @@ include ./fork.pug
 						each swagTag in swag.tags
 							span!=swagTag
 					div.flex.img-container
-						a(href=swag.reference target="_blank")
+						a(href=swag.reference target="_blank").image-link
 							picture
 								source(type="image/webp" srcset=swag.images.webp)
 								source(type="image/jpeg" srcset=swag.images.jpeg)
 								img(src=swag.images.jpeg alt=swag.name + " swag you can get")
 					p.description!=swag.description
-					a(href=swag.reference target="_blank") Check it out
+					a(href=swag.reference target="_blank").reference-link Check it out
 
 	footer.flex
 		.item.flex

--- a/src/styl/imports/card.styl
+++ b/src/styl/imports/card.styl
@@ -52,9 +52,6 @@
 		color #444
 		text-decoration none
 
-		&:hover
-			border-bottom 2px solid #444
-
 	img
 		height 100%
 		width auto
@@ -65,6 +62,12 @@
 		width 100%
 		overflow hidden
 		padding-bottom 15px
+
+		&:hover
+			border-bottom 2px solid #444
+
+	.reference-link
+		border-bottom 2px solid #444
 
 	&:hover
 		img

--- a/src/styl/imports/card.styl
+++ b/src/styl/imports/card.styl
@@ -51,7 +51,9 @@
 	a
 		color #444
 		text-decoration none
-		border-bottom 2px solid #444
+
+		&:hover
+			border-bottom 2px solid #444
 
 	img
 		height 100%
@@ -67,5 +69,3 @@
 	&:hover
 		img
 			transform rotate(3deg) scale(1.05)
-		a
-			border none

--- a/src/styl/imports/card.styl
+++ b/src/styl/imports/card.styl
@@ -63,9 +63,6 @@
 		overflow hidden
 		padding-bottom 15px
 
-		&:hover
-			border-bottom 2px solid #444
-
 	.reference-link
 		border-bottom 2px solid #444
 


### PR DESCRIPTION
<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->
Changes are for issue #412. As per description mentioned on the issue, I have changed the CSS to show borders under anchor tags only when they are hovered upon..not on hover of item.


<!-- Thanks for contributing! -->
