### PR TITLE
Remove image link bottom border

### DIFF
--- a/src/pug/includes/body.pug
+++ b/src/pug/includes/body.pug
@@ -60,7 +60,7 @@ include ./fork.pug
 						each swagTag in swag.tags
 							span!=swagTag
 					div.flex.img-container
-						a(href=swag.reference target="_blank")
+						a(href=swag.reference target="_blank").picture-link
 							picture
 								source(type="image/webp" srcset=swag.images.webp)
 								source(type="image/jpeg" srcset=swag.images.jpeg)

--- a/src/styl/imports/card.styl
+++ b/src/styl/imports/card.styl
@@ -64,6 +64,9 @@
 		overflow hidden
 		padding-bottom 15px
 
+	.picture-link
+		border 0
+
 	&:hover
 		img
 			transform rotate(3deg) scale(1.05)


### PR DESCRIPTION
- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->

Remove the image link underline/border. Kept the behavior of the line going away for the text, when hovering the image, because I thought it was interesting. What do you think, should I remove that as well? 

<!-- Thanks for contributing! -->
