### PR TITLE
add: QMK to data.json

### DIFF
--- a/data.json
+++ b/data.json
@@ -360,6 +360,15 @@
     "tags": ["hacktoberfest", "accessories"]
   },
   {
+    "name": "QMK",
+    "difficulty": "medium",
+    "description": "Four interactions with a QMK repo or $15 to cKeys non-profit will qualify you for a QMK T-shirt.",
+    "reference": "https://hacktoberfest.qmk.fm/",
+    "image": "https://hacktoberfest.qmk.fm/img/social.jpg",
+    "dateAdded": "2019-10-14T16:16:36.000Z",
+    "tags": ["clothing", "hacktoberfest"]
+  },
+  {
     "name": "SendGrid",
     "difficulty": "hard",
     "description": "Five accepted pull results from SendGrid will qualify you for a special edition SendGrid Hacktoberfest T-shirt.",


### PR DESCRIPTION
- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

This PR is not a duplicate however there is an [open PR for this same swag](https://github.com/swapagarwal/swag-for-dev/pull/370). However, since the PR has requested changes and has not been updated in some time I thought I would help out. I hope that is okay.

I kept the description short and sweet in order to play nicely in the description field.

The assets for https://hacktoberfest.qmk.fm/ can be found here:

> https://github.com/qmk/hacktoberfest/tree/master/img

It does not seem have anything that looks great on the site's image element however I believe the [social.jpg](https://github.com/qmk/hacktoberfest/tree/master/img/social.jpg) asset has a nice contrast to the white background of the site.

Fixes #368 
Closes #370 