### PR TITLE
update WhatIsMyBrowser to expired

### DIFF
--- a/data.json
+++ b/data.json
@@ -573,7 +573,7 @@
     "reference": "https://developers.whatismybrowser.com/api/swag/",
     "image": "https://developers.whatismybrowser.com/static/main/content/api/swag/whatismybrowser-stickers.jpg",
     "dateAdded": "2018-10-12T13:05:05.000Z",
-    "tags": ["stickers"]
+    "tags": ["stickers", "expired"]
   },
   {
     "name": "Xamarin",


### PR DESCRIPTION
<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [ ] I've checked that this isn't a new swag opportunity proposal.
- [ ] I've checked that this isn't a duplicate pull request.


<!-- Describe your changes below -->
Set WhatIsMyBrowser to expired before of it's new policy. Only paid accounts can get swag.

Fixes #539 

<!-- Thanks for contributing! -->
