### PR TITLE
fix(ui): hide newsletter panel on no-script

### DIFF
--- a/src/pug/includes/head.pug
+++ b/src/pug/includes/head.pug
@@ -15,4 +15,4 @@ link(rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mobius1-selectr@2.4.13/
 
 noscript
 	style.
-		.buttons {display: none}
+		.buttons, .newsletter {display: none}


### PR DESCRIPTION
<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

<!-- Describe your changes below -->

When Javascript is disabled, `upscri.be` (the newsletter service) does not shows at the bottom. Instead of letting an empty zone, hide the block.

We might consider using a provider who keeps working without Javascript, it's kind of a shame I'd say!

<!-- Thanks for contributing! -->
