### PR TITLE
fix(swag): set Netlify offer as expired

### DIFF
--- a/data.json
+++ b/data.json
@@ -357,7 +357,7 @@
     "reference": "https://swag.netlify.com/",
     "image": "https://swag.netlify.com/images/laptop-sticker.jpg",
     "dateAdded": "2018-04-27T19:36:39.000Z",
-    "tags": ["stickers"]
+    "tags": ["stickers", "expired"]
   },
   {
     "name": "Nexmo",


### PR DESCRIPTION
Netlify offer is expired. See https://swag.netlify.com/