### PR TITLE
chore(ci): fix npm cache path not being expanded

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
 
     - uses: actions/cache@v1
       with:
-        path: $HOME/.npm
+        path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
@@ -36,7 +36,7 @@ jobs:
 
     - uses: actions/cache@v1
       with:
-        path: $HOME/.npm
+        path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-


### PR DESCRIPTION
See https://github.com/swapagarwal/swag-for-dev/runs/668199195

![image](https://user-images.githubusercontent.com/8191198/81758063-1202e500-94c1-11ea-8cec-c8e7e698e6b8.png)

`$HOME` is not expanded to `/home/runner` which causes cache Post Run action to fail.
Changing it to `~` as seen in https://github.com/actions/cache/blob/master/examples.md#node---npm fixes the issue.