### PR TITLE
chore(swag): set blockstack shirt as expired

### DIFF
--- a/data.json
+++ b/data.json
@@ -78,7 +78,7 @@
     "reference": "https://community.blockstack.org/z2d-shirt",
     "image": "https://static.tildacdn.com/tild6433-6535-4833-b932-323062343930/Zero_to_Dapp_shirt_p.png",
     "dateAdded": "2020-01-19T05:30:00.000Z",
-    "tags": ["clothing"]
+    "tags": ["clothing", "expired"]
   },
   {
     "name": "CircleCI",


### PR DESCRIPTION
Fixes #633 