### PR TITLE
Update Gitpod link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Thanks again, we hope to see you soon! ❤
 
 Contribute to swag-for-dev using a fully featured online development environment that will automatically: clone the repo, install the dependencies and start the webserver.
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://https://gitpod.io/#https://github.com/swapagarwal/swag-for-dev)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/swapagarwal/swag-for-dev)
 
 ### Start using NPM
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Thanks again, we hope to see you soon! ❤
 
 Contribute to swag-for-dev using a fully featured online development environment that will automatically: clone the repo, install the dependencies and start the webserver.
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://https://gitpod.io/#https://github.com/swapagarwal/swag-for-dev)
 
 ### Start using NPM
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![closed pull requests](https://img.shields.io/github/issues-pr-closed/swapagarwal/swag-for-dev.svg)](htps://github.com/swapagarwal/swag-for-dev/pulls?q=is%3Apr+is%3Aclosed)
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](https://github.com/swapagarwal/swag-for-dev/fork)
 [![Join the chat on Slack](https://img.shields.io/badge/chat-on%20slack-E01563.svg)](https://join.slack.com/t/swagfordev/shared_invite/zt-6ecwtoap-QR1sl1782xTCiGzBnSJt3g)
-[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/swapagarwal/swag-for-dev)
 
 As a developer, nothing piques my interest more than developer swag! devSwag is a curated list of verified swag opportunities for developers.
 
@@ -43,7 +43,7 @@ Please consider donating to cover up our hosting costs. 🙏
 
 Contribute to swag-for-dev using a fully featured online development environment that will automatically: clone the repo, install the dependencies and start the webserver.
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/swapagarwal/swag-for-dev)
 
 ### Local & Docker setup
 


### PR DESCRIPTION
I was trying to set up development to add new swag opportunities, and found that the Gitpod links aren't working. They redirect to a 404. This is the working format of how Gitpod URLs work. I tested this on my machine and was able to make this PR from Gitpod.