### PR TITLE
Safari bug on hover

### DIFF
--- a/src/styl/imports/card.styl
+++ b/src/styl/imports/card.styl
@@ -105,6 +105,8 @@
 	.img-container
 		height 300px
 		width 100%
+		position relative
+		z-index 99
 		overflow hidden
 		border-radius 10px 10px 0 0
 		border 1px solid grey-color


### PR DESCRIPTION
- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

Border radius disappears on hover while an image in **img-container** is being zoomed. With this code it fixes the issue in Safari 14.0.

[here is a preview](https://i.postimg.cc/t41T724J/Screenshot-2020-10-01-at-15-12-37.png)
(on the left the card is hovered, and doesn't have border)