### PR TITLE
fix: set Blockstack opportunity as expired

### DIFF
--- a/data.json
+++ b/data.json
@@ -81,6 +81,15 @@
     "tags": ["clothing", "expired"]
   },
   {
+    "name": "Blockstack",
+    "difficulty": "easy",
+    "description": "Get up to 5 awesome stickers from Blockstack! Don't be evil!",
+    "reference": "https://web.archive.org/web/20200616131621/https://blockstack.myshopify.com/collections/frontpage/products/dont-be-evil-stickers",
+    "image": "https://i.imgur.com/sHgpibu.jpg",
+    "dateAdded": "2020-07-21T14:42:00.000Z",
+    "tags": ["stickers, expired"]
+  },
+  {
     "name": "Camunda",
     "difficulty": "medium",
     "description": "Participants who complete the Camunda challenge will earn a Camunda x Hacktoberfest 2020 t-shirt and some nifty stickers.",

--- a/data.json
+++ b/data.json
@@ -81,15 +81,6 @@
     "tags": ["clothing", "expired"]
   },
   {
-    "name": "Blockstack",
-    "difficulty": "easy",
-    "description": "Get up to 5 awesome stickers from Blockstack! Don't be evil!",
-    "reference": "https://web.archive.org/web/20200616131621/https://blockstack.myshopify.com/collections/frontpage/products/dont-be-evil-stickers",
-    "image": "https://i.imgur.com/sHgpibu.jpg",
-    "dateAdded": "2020-07-21T14:42:00.000Z",
-    "tags": ["stickers"]
-  },
-  {
     "name": "Camunda",
     "difficulty": "medium",
     "description": "Participants who complete the Camunda challenge will earn a Camunda x Hacktoberfest 2020 t-shirt and some nifty stickers.",

--- a/data.json
+++ b/data.json
@@ -87,7 +87,7 @@
     "reference": "https://web.archive.org/web/20200616131621/https://blockstack.myshopify.com/collections/frontpage/products/dont-be-evil-stickers",
     "image": "https://i.imgur.com/sHgpibu.jpg",
     "dateAdded": "2020-07-21T14:42:00.000Z",
-    "tags": ["stickers, expired"]
+    "tags": ["stickers", "expired"]
   },
   {
     "name": "Camunda",


### PR DESCRIPTION
<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->
I just checked if I was able to claim the BlockStack stickers opportunity, it seems that web archive link is not working any more. I dared to remove it, but if there's something else that cen be used for that we can update the link.


<!-- Thanks for contributing! -->
