### PR TITLE
[#679] Updated information for CircleCi Hacktoberfest 2020.

### DIFF
--- a/data.json
+++ b/data.json
@@ -102,10 +102,10 @@
     "name": "CircleCI",
     "difficulty": "medium",
     "description": "Participate in #Orbtoberfest with CircleCI and claim limited edition swag! 1 - 3 pull requests: Limited-Edition Sticker, 4+ pull requests: Limited-Edition T-shirt",
-    "reference": "https://hacktoberfest.circleci.com/#/",
+    "reference": "https://hacktoberfest.circleci.com",
     "image": "https://i.imgur.com/MkxWDck.jpg",
-    "dateAdded": "2019-09-29T19:30:00.000Z",
-    "tags": ["clothing", "hacktoberfest", "stickers", "expired"]
+    "dateAdded": "2020-10-02T19:30:00.000Z",
+    "tags": ["clothing", "hacktoberfest", "stickers"]
   },
   {
     "name": "Codeship",


### PR DESCRIPTION
<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [X] I've checked that this isn't a new swag opportunity proposal.
- [X] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->

There was information for CircleCi Hacktober for 2019. I verifed and updated the information for 2020.

<!-- Thanks for contributing! -->
Fixes #679 