### PR TITLE
feat: expose dataset on website

### DIFF
--- a/src/pug/includes/body.pug
+++ b/src/pug/includes/body.pug
@@ -96,6 +96,9 @@
 		.item.flex
 			p Maintained by #[a(href="https://github.com/aslafy-z") Zadkiel] and #[a(href="https://vikaspotluri.me") Vikas Potluri]
 		.item.flex
+			a(href="https://github.com/swapagarwal/swag-for-dev/blob/master/data.json") View Data
+			br
+		.item.flex
 			p This site is powered by #[a(href="https://www.netlify.com") Netlify]
 		.item.flex
 			p Want your company's swag to be listed / unlisted? Want to advertise? #[a(href="https://t.me/swapagarwal") Contact us].


### PR DESCRIPTION
<!--
Added a link to the dataset on the website so that it can be viewed by everyone using the site.
-->

- [X] I've checked that this isn't a new swag opportunity proposal.
- [X] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->
People viewing the website now can click on a hyperlink at the bottom of the page to see the data being hosted on the website for themselves.


<!-- Thanks for contributing! -->
 Fixes #534