### PR TITLE
fix(swag): set Img Bot opportunity as expired

### DIFF
--- a/data.json
+++ b/data.json
@@ -312,7 +312,7 @@
     "reference": "https://docs.google.com/forms/d/e/1FAIpQLScpL5wT5dsFTXZou49p7_W7Y2sbMeqKulvDrwHQabecc4YF7w/viewform",
     "image": "https://pbs.twimg.com/media/EJzGQGKUwAALlSC?format=jpg&name=4096x4096",
     "dateAdded": "2020-01-02T05:30:00.000Z",
-    "tags": ["stickers"]
+    "tags": ["stickers", "expired"]
   },
   {
     "name": "Indeed",


### PR DESCRIPTION
Added the expired tag in Img bot they are DISCONTINUED

<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->



<!-- Thanks for contributing! -->
