### PR TITLE
Add hashnode blogging opportunity for swag

### DIFF
--- a/data.json
+++ b/data.json
@@ -288,6 +288,15 @@
     "tags": ["clothing", "hacktoberfest", "stickers", "expired"]
   },
   {
+    "name": "Hashnode",
+    "difficulty": "easy",
+    "description": "Write blogs on tracks provided by <a href='https://www.commclassroom.org/hashnode'>Comclassroom</a> and get a chance to win a Hashnode t-shirt and a grand prizes like devices, cash every month. Write blogs on <a href='https://hashnode.com'>Hashnode</a> with the tag #BlogsWithCC to get into the raffle of the month.",
+    "reference": "https://www.commclassroom.org/hashnode",
+    "image": "https://d1aettbyeyfilo.cloudfront.net/kunalk/29590480_1658759012EyhEvent.webp",
+    "dateAdded": "2022-10-09T09:20:00.000Z",
+    "tags": ["clothing", "stickers", "device", "accessories", "donation"]
+  },
+  {
     "name": "Hasura",
     "difficulty": "medium",
     "description": "Submit a PR to Hasura's <a href='https://github.com/hasura/graphql-engine'>GraphQL Engine</a> or <a href='https://github.com/hasura/learn-graphql'>GraphQL Tutorial Series</a> during Hacktoberfest 2020 and get a Hasura sticker pack. For all valid PRs closing an issue with the label hacktoberfest, a secret swag will be sent.",


### PR DESCRIPTION
<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [X] I've checked that this isn't a new swag opportunity proposal.
- [X] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->
I have added new swag opportunities for developers who like blogging.

Hashnode, a popular blogging platform is organizing blogging event every month where you can win stickers, T-shirt,s and new gadgets/prizes every month.

It is valid, and I have also received swag previously.

Issue #1011 

<!-- Thanks for contributing! -->
