### PR TITLE
fix: checkbox bg color white issue

### DIFF
--- a/src/styl/imports/card.styl
+++ b/src/styl/imports/card.styl
@@ -172,6 +172,7 @@
 				border .8em solid secondary-color
 				animation bounce 200ms cubic-bezier(.4,.0,.23,1)
 				opacity 1
+				background-color secondary-color				
 
 				&::before
 					content ''

--- a/src/styl/imports/card.styl
+++ b/src/styl/imports/card.styl
@@ -172,7 +172,7 @@
 				border .8em solid secondary-color
 				animation bounce 200ms cubic-bezier(.4,.0,.23,1)
 				opacity 1
-				background-color secondary-color				
+				background-color secondary-color
 
 				&::before
 					content ''


### PR DESCRIPTION
fix #1063 checkbox background is not fully blue when we select done option now the background is fully colord as secondary bg in file

- [Y] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->
i have chenged card.styl file to fix this issue

<!-- Thanks for contributing! -->
