### PR TITLE
Added Depth's Swag 

### DIFF
--- a/data.json
+++ b/data.json
@@ -197,6 +197,15 @@
     "dateAdded": "2020-10-01T19:00:00.000Z",
     "tags": ["stickers", "clothing", "hacktoberfest", "expired"]
   },
+   {
+    "name": "Depths",
+    "difficulty": "Medium",
+    "description": "Read 2 curated learning resources daily, share insights in comments, and complete 30 days of challenges for rewards, including a Hacktoberfest merged PR.",
+    "reference": "https://www.depths.so/30daysopensource",
+    "image": "https://pbs.twimg.com/media/F05qhWUakAERL9w?format=jpg&name=900x900",
+    "dateAdded": "2023-10-10T14:30:00.000Z.",
+    "tags": ["clothing", "stickers", "hacktoberfest" ]
+  },
   {
     "name": "Deque",
     "difficulty": "easy",

--- a/data.json
+++ b/data.json
@@ -315,6 +315,15 @@
     "tags": ["clothing", "hacktoberfest", "stickers", "expired"]
   },
   {
+    "name": "HackSquad 2023",
+    "difficulty": "hard",
+    "description": "The top 60 squads will win awesome swag! around ~300 winners!",
+    "reference": "https://www.hacksquad.dev/#swag",
+    "image": "https://pbs.twimg.com/media/F3KWb-qaoAAlUT1?format=jpg&name=900x900",
+    "dateAdded": "2023-10-10T16:45:00.000Z.",
+    "tags": ["clothing", "hacktoberfest", "stickers"]
+  },
+  {
     "name": "Hasura",
     "difficulty": "medium",
     "description": "Submit a PR to Hasura's <a href='https://github.com/hasura/graphql-engine'>GraphQL Engine</a> or <a href='https://github.com/hasura/learn-graphql'>GraphQL Tutorial Series</a> during Hacktoberfest 2020 and get a Hasura sticker pack. For all valid PRs closing an issue with the label hacktoberfest, a secret swag will be sent.",

--- a/data.json
+++ b/data.json
@@ -315,15 +315,6 @@
     "tags": ["clothing", "hacktoberfest", "stickers", "expired"]
   },
   {
-    "name": "HackSquad 2023",
-    "difficulty": "hard",
-    "description": "The top 60 squads will win awesome swag! around ~300 winners!",
-    "reference": "https://www.hacksquad.dev/#swag",
-    "image": "https://pbs.twimg.com/media/F3KWb-qaoAAlUT1?format=jpg&name=900x900",
-    "dateAdded": "2023-10-10T16:45:00.000Z.",
-    "tags": ["clothing", "hacktoberfest", "stickers"]
-  },
-  {
     "name": "Hasura",
     "difficulty": "medium",
     "description": "Submit a PR to Hasura's <a href='https://github.com/hasura/graphql-engine'>GraphQL Engine</a> or <a href='https://github.com/hasura/learn-graphql'>GraphQL Tutorial Series</a> during Hacktoberfest 2020 and get a Hasura sticker pack. For all valid PRs closing an issue with the label hacktoberfest, a secret swag will be sent.",


### PR DESCRIPTION
Add Swag Opportunity for Depths' 30 Days Open Source Learning Challenge

<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->
I've added an opportunity to get swags from Depths by Completing the #30DaysOpenSource and including a Hacktoberfest merged PR. This solves the issue https://github.com/swapagarwal/swag-for-dev/issues/1077


<!-- Thanks for contributing! -->
