### PR TITLE
Fix image download error handling in "gulpfile.js" and "downloadSingleImage.js" from issue #1283

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,64 +1,68 @@
-const del = require('del');
-const gulp = require('gulp');
-const cachebust = require('gulp-rev');
-const cacheClean = require('gulp-rev-delete-original');
-const babel = require('gulp-babel');
-const uglify = require('gulp-uglify-es').default;
-const pug = require('gulp-pug');
-const htmlmin = require('gulp-htmlmin');
-const stylus = require('gulp-stylus');
-const webserver = require('gulp-webserver');
-const concat = require('gulp-concat');
-const responsive = require('gulp-responsive');
-const merge = require('merge-stream');
-const postcss = require('gulp-postcss');
-const autoprefixer = require('autoprefixer');
-const {readFile} = require('fs').promises;
+const del = require("del");
+const gulp = require("gulp");
+const cachebust = require("gulp-rev");
+const cacheClean = require("gulp-rev-delete-original");
+const babel = require("gulp-babel");
+const uglify = require("gulp-uglify-es").default;
+const pug = require("gulp-pug");
+const htmlmin = require("gulp-htmlmin");
+const stylus = require("gulp-stylus");
+const webserver = require("gulp-webserver");
+const concat = require("gulp-concat");
+const responsive = require("gulp-responsive");
+const merge = require("merge-stream");
+const postcss = require("gulp-postcss");
+const autoprefixer = require("autoprefixer");
+const { readFile } = require("fs").promises;
 
-const {swagList, swagImages} = require('./scripts/get-data');
-const downloadImages = require('./scripts/download-images');
+const { swagList, swagImages } = require("./scripts/get-data");
+const downloadImages = require("./scripts/download-images");
 
-const PRODUCTION = process.env.NODE_ENV === 'production';
+const PRODUCTION = process.env.NODE_ENV === "production";
 
-const REV_PATH = './dist/rev-manifest.json';
+const REV_PATH = "./dist/rev-manifest.json";
 const RESIZE_OPTS = {
 	quality: 90,
 	progressive: true,
 	compressionLevel: 9,
 	errorOnEnlargement: false,
-	errorOnUnusedConfig: false
+	errorOnUnusedConfig: false,
 };
 
 let manifest = {
-	'css/index.css': 'css/index.css',
-	'js/index.js': 'js/index.js'
+	"css/index.css": "css/index.css",
+	"js/index.js": "js/index.js",
 };
 
-const assetsToBeInlined = ['css/index.css'];
+const assetsToBeInlined = ["css/index.css"];
 
 async function getInlinedAssets(config, manifest) {
 	const fileMap = new Map();
 	const promises = [];
-	const assetBasePath = 'dist/assets/';
+	const assetBasePath = "dist/assets/";
 
-	config.forEach(name => {
+	config.forEach((name) => {
 		const assetPath = assetBasePath + manifest[name];
-		promises.push(readFile(assetPath, 'utf8')
-			.then(contents => fileMap.set(name, contents)));
+		promises.push(
+			readFile(assetPath, "utf8").then((contents) =>
+				fileMap.set(name, contents)
+			)
+		);
 	});
 
 	await Promise.all(promises);
 	return fileMap;
 }
 
-gulp.task('pug', async done => {
-	const tags = Array.from(swagList.reduce(
-		(tagList, {tags}) => {
-			tags.filter(tag => tag !== 'expired').forEach(tag => tagList.add(tag));
+gulp.task("pug", async (done) => {
+	const tags = Array.from(
+		swagList.reduce((tagList, { tags }) => {
+			tags
+				.filter((tag) => tag !== "expired")
+				.forEach((tag) => tagList.add(tag));
 			return tagList;
-		},
-		new Set()
-	)).sort();
+		}, new Set())
+	).sort();
 
 	if (PRODUCTION) {
 		delete require.cache[require.resolve(REV_PATH)];
@@ -66,128 +70,154 @@ gulp.task('pug', async done => {
 	}
 
 	const bustedAssets = {
-		css: `/assets/${manifest['css/index.css']}`,
-		js: `/assets/${manifest['js/index.js']}`
+		css: `/assets/${manifest["css/index.css"]}`,
+		js: `/assets/${manifest["js/index.js"]}`,
 	};
 
 	const inlinedAssets = await getInlinedAssets(assetsToBeInlined, manifest);
 
-	gulp.src('src/pug/*.pug')
-		.pipe(pug({
-			pretty: true,
-			locals: {swagList, tags, bustedAssets, inlinedAssets}
-		}))
-		.pipe(htmlmin({
-			collapseWhitespace: true,
-			removeComments: true
-		}))
-		.pipe(gulp.dest('dist/'))
-		.on('end', () => done());
+	gulp
+		.src("src/pug/*.pug")
+		.pipe(
+			pug({
+				pretty: true,
+				locals: { swagList, tags, bustedAssets, inlinedAssets },
+			})
+		)
+		.pipe(
+			htmlmin({
+				collapseWhitespace: true,
+				removeComments: true,
+			})
+		)
+		.pipe(gulp.dest("dist/"))
+		.on("end", () => done());
 });
 
-gulp.task('styl', () => {
-	return gulp.src('src/styl/index.styl')
-		.pipe(stylus({compress: true}))
-		.pipe(postcss([
-			autoprefixer()
-		]))
-		.pipe(gulp.dest('dist/assets/css'));
+gulp.task("styl", () => {
+	return gulp
+		.src("src/styl/index.styl")
+		.pipe(stylus({ compress: true }))
+		.pipe(postcss([autoprefixer()]))
+		.pipe(gulp.dest("dist/assets/css"));
 });
 
-gulp.task('binaries', () => {
+gulp.task("binaries", () => {
 	const paths = {
-		'src/img/*': 'dist/assets/img',
-		'src/fonts/*': 'dist/assets/fonts'
+		"src/img/*": "dist/assets/img",
+		"src/fonts/*": "dist/assets/fonts",
 	};
 
-	return merge(Object.entries(paths).map(([from, to]) =>
-		gulp.src(from).pipe(gulp.dest(to))
-	));
+	return merge(
+		Object.entries(paths).map(([from, to]) =>
+			gulp.src(from).pipe(gulp.dest(to))
+		)
+	);
 });
 
-gulp.task('js', () => {
-	const presets = [
-		['@babel/env', {targets: {browsers: ['> 75%']}}]
-	];
-	return gulp.src('src/js/*.js')
-		.pipe(concat('index.js'))
-		.pipe(babel({presets}))
+gulp.task("js", () => {
+	const presets = [["@babel/env", { targets: { browsers: ["> 75%"] } }]];
+	return gulp
+		.src("src/js/*.js")
+		.pipe(concat("index.js"))
+		.pipe(babel({ presets }))
 		.pipe(uglify())
-		.pipe(gulp.dest('dist/assets/js'));
+		.pipe(gulp.dest("dist/assets/js"));
 });
 
-gulp.task('swag-img:clean', () => {
-	return del('dist/assets/swag-img/*');
+gulp.task("swag-img:clean", () => {
+	return del("dist/assets/swag-img/*");
 });
 
-gulp.task('swag-img:download', async () => {
-	const success = await downloadImages(swagImages, 'dist/assets/swag-img');
-	if (!success) {
-		throw new Error('Failed to download images');
+gulp.task("swag-img:download", async () => {
+	try {
+		const success = await downloadImages(swagImages, "dist/assets/swag-img");
+		if (!success) {
+			console.warn(
+				"Some images failed to download, but continuing with the build process."
+			);
+		}
+	} catch (error) {
+		console.error("An error occurred during image downloading:", error.message);
 	}
 });
 
-gulp.task('swag-img:optimize', cb => {
+gulp.task("swag-img:optimize", (cb) => {
 	const jpegOutputConfig = {
-		name: '*.jpeg',
+		name: "*.jpeg",
 		height: 300,
-		flatten: true
+		flatten: true,
 	};
-	const webpOutputConfig = Object.assign({
-		rename: i => `${i.basename}.webp`
-	}, jpegOutputConfig);
+	const webpOutputConfig = Object.assign(
+		{
+			rename: (i) => `${i.basename}.webp`,
+		},
+		jpegOutputConfig
+	);
 
-	return gulp.src('dist/assets/swag-img/*')
+	return gulp
+		.src("dist/assets/swag-img/*")
 		.pipe(responsive([jpegOutputConfig, webpOutputConfig], RESIZE_OPTS))
-		.pipe(gulp.dest('dist/assets/swag-img'))
-		.on('end', () => {
-			swagList.forEach(swag => {
-				const baseName = swag.image.split('.').slice(0, -1).join('.');
+		.pipe(gulp.dest("dist/assets/swag-img"))
+		.on("end", () => {
+			swagList.forEach((swag) => {
+				const baseName = swag.image.split(".").slice(0, -1).join(".");
 				swag.images = {
 					jpeg: swag.image,
-					webp: `${baseName}.webp`
+					webp: `${baseName}.webp`,
 				};
 			});
 			cb();
 		});
 });
 
-gulp.task('swag-img', gulp.series('swag-img:clean', 'swag-img:download', 'swag-img:optimize'));
+gulp.task(
+	"swag-img",
+	gulp.series("swag-img:clean", "swag-img:download", "swag-img:optimize")
+);
 
-gulp.task('clean:styl', () => del('dist/assets/css/*'));
-gulp.task('clean:js', () => del('dist/assets/js/*'));
-gulp.task('clean:binaries', () => del(['dist/assets/img/*', 'dist/assets/fonts/*']));
-gulp.task('clean:assets', gulp.parallel('clean:styl', 'clean:js', 'clean:binaries'));
-gulp.task('clean:pug', () => del('dist/index.html'));
-gulp.task('clean', gulp.parallel('clean:pug', 'clean:assets'));
+gulp.task("clean:styl", () => del("dist/assets/css/*"));
+gulp.task("clean:js", () => del("dist/assets/js/*"));
+gulp.task("clean:binaries", () =>
+	del(["dist/assets/img/*", "dist/assets/fonts/*"])
+);
+gulp.task(
+	"clean:assets",
+	gulp.parallel("clean:styl", "clean:js", "clean:binaries")
+);
+gulp.task("clean:pug", () => del("dist/index.html"));
+gulp.task("clean", gulp.parallel("clean:pug", "clean:assets"));
 
-gulp.task('cachebust', cb => {
+gulp.task("cachebust", (cb) => {
 	if (!PRODUCTION) {
 		return cb();
 	}
 
-	const basePath = 'dist/assets';
+	const basePath = "dist/assets";
 	const bustedFiles = [
-		'dist/assets/css/*',
-		'dist/assets/js/*',
-		'dist/assets/swag-img/*'
+		"dist/assets/css/*",
+		"dist/assets/js/*",
+		"dist/assets/swag-img/*",
 	];
 
-	return gulp.src(bustedFiles, {base: basePath})
+	return gulp
+		.src(bustedFiles, { base: basePath })
 		.pipe(cachebust())
 		.pipe(cacheClean())
 		.pipe(gulp.dest(basePath))
-		.pipe(cachebust.manifest({
-			path: REV_PATH,
-			base: basePath
-		}))
+		.pipe(
+			cachebust.manifest({
+				path: REV_PATH,
+				base: basePath,
+			})
+		)
 		.pipe(gulp.dest(basePath))
-		.on('end', () => {
+		.on("end", () => {
 			delete require.cache[require.resolve(REV_PATH)];
 			manifest = require(REV_PATH);
-			swagList.forEach(swag => {
+			swagList.forEach((swag) => {
 				Object.entries(swag.images).forEach(([extension, fileName]) => {
-					fileName = `swag-img/${fileName.split('/').pop()}`;
+					fileName = `swag-img/${fileName.split("/").pop()}`;
 					if (!manifest[fileName]) {
 						console.warn(`Unable to find image ${fileName} in the manifest`);
 						return;
@@ -201,27 +231,33 @@ gulp.task('cachebust', cb => {
 		});
 });
 
-gulp.task('webserver', () => {
-	return gulp.src('dist')
-		.pipe(webserver({
+gulp.task("webserver", () => {
+	return gulp.src("dist").pipe(
+		webserver({
 			livereload: true,
 			open: true,
-			host: process.env.GULP_LISTEN_HOST || '127.0.0.1',
-			port: Number.parseInt(process.env.GULP_LISTEN_PORT || '8080', 10)
-		}));
+			host: process.env.GULP_LISTEN_HOST || "127.0.0.1",
+			port: Number.parseInt(process.env.GULP_LISTEN_PORT || "8080", 10),
+		})
+	);
 });
 
-gulp.task('watch', () => {
-	gulp.watch('src/pug/**/*.pug', gulp.series('pug'));
-	gulp.watch('src/styl/**/*.styl', gulp.series('styl'));
-	gulp.watch('src/js/*.js', gulp.series('js'));
+gulp.task("watch", () => {
+	gulp.watch("src/pug/**/*.pug", gulp.series("pug"));
+	gulp.watch("src/styl/**/*.styl", gulp.series("styl"));
+	gulp.watch("src/js/*.js", gulp.series("js"));
 });
 
-gulp.task('build', gulp.series(
-	'clean',
-	gulp.parallel(
-		gulp.series('swag-img', 'styl', 'cachebust', 'pug'), 'js', 'binaries'
+gulp.task(
+	"build",
+	gulp.series(
+		"clean",
+		gulp.parallel(
+			gulp.series("swag-img", "styl", "cachebust", "pug"),
+			"js",
+			"binaries"
+		)
 	)
-));
+);
 
-gulp.task('default', gulp.series('build', 'webserver', 'watch'));
+gulp.task("default", gulp.series("build", "webserver", "watch"));

--- a/scripts/download-images.js
+++ b/scripts/download-images.js
@@ -1,21 +1,20 @@
-const {promisify} = require('util');
-const {pipeline: pipeline_} = require('stream');
-const {createWriteStream} = require('fs');
-const {mkdir, unlink} = require('fs').promises;
-const path = require('path');
-const {performance} = require('perf_hooks');
-const Queue = require('p-queue').default;
-const chalk = require('chalk');
-const got = require('got').default.extend({
-	timeout: 30000,
-	retry: 1
+const { promisify } = require("util");
+const { pipeline: pipeline_ } = require("stream");
+const { createWriteStream } = require("fs");
+const { mkdir, unlink } = require("fs").promises;
+const path = require("path");
+const { performance } = require("perf_hooks");
+const Queue = require("p-queue").default;
+const chalk = require("chalk");
+const got = require("got").default.extend({
+	timeout: 5000,
+	retry: 0,
 });
 
 const pipeline = promisify(pipeline_);
 
-const getTime = start => {
+const getTime = (start) => {
 	const end = performance.now();
-
 	const diff = end - start;
 	let humanTime = `${diff.toFixed(2)}ms`;
 
@@ -28,41 +27,79 @@ const getTime = start => {
 	return humanTime;
 };
 
-async function downloadSingleImage({url, errors, outFile}) {
+async function downloadSingleImage({ url, errors, outFile, retries = 3 }) {
 	const start = performance.now();
-	try {
-		console.log(`${chalk.yellow('Downloading')} ${chalk.cyan(url)} to ${chalk.magenta(outFile)}`);
-		await pipeline(got.stream({url}), createWriteStream(outFile));
-		const time = getTime(start);
-		console.log(`${chalk.green('Downloaded')} ${chalk.cyan(url)} [${time}]`);
-	} catch (error) {
-		const time = getTime(start);
-		console.log(`${chalk.red('Failed downloading')} ${chalk.cyan(url)} [${time}]: ${error.message}`);
-		errors.push(error);
+	let attempt = 0;
 
+	while (attempt < retries) {
 		try {
-			await unlink(outFile);
-		} catch {}
+			console.log(
+				`${chalk.yellow("Downloading")} ${chalk.cyan(url)} to ${chalk.magenta(
+					outFile
+				)}`
+			);
+			await pipeline(got.stream({ url }), createWriteStream(outFile));
+			const time = getTime(start);
+			console.log(`${chalk.green("Downloaded")} ${chalk.cyan(url)} [${time}]`);
+			return;
+		} catch (error) {
+			attempt++;
+			const time = getTime(start);
+			console.log(
+				`${chalk.red("Failed downloading")} ${chalk.cyan(url)} [${time}]: ${
+					error.message
+				}`
+			);
+			errors.push(error);
+
+			// Cleanup partial download if it exists
+			try {
+				await unlink(outFile);
+			} catch (unlinkError) {
+				console.error(`Error deleting file ${outFile}: ${unlinkError.message}`);
+			}
+
+			// If we reach the max retries, log an error
+			if (attempt === retries) {
+				console.log(
+					`${chalk.red("Max retries reached for")} ${chalk.cyan(url)}.`
+				);
+			}
+		}
 	}
 }
 
 module.exports = async function (list, dest) {
-	const queue = new Queue({concurrency: 15});
+	const queue = new Queue({ concurrency: 15 });
 	const errors = [];
 
-	await mkdir(dest, {recursive: true});
+	await mkdir(dest, { recursive: true });
 
-	for (const {url, file} of list) {
-		queue.add(() => downloadSingleImage({url, errors, outFile: path.join(dest, file)}));
+	for (const { url, file } of list) {
+		queue.add(() =>
+			downloadSingleImage({
+				url,
+				errors,
+				outFile: path.join(dest, file),
+				retries: 3,
+			})
+		);
 	}
 
 	await queue.onIdle();
 
 	const totalErrors = errors.length;
-	const errorText = totalErrors > 0 ? chalk.red(totalErrors) : chalk.green(totalErrors);
-	const plural = totalErrors === 1 ? '' : 's';
+	const errorText =
+		totalErrors > 0 ? chalk.red(totalErrors) : chalk.green(totalErrors);
+	const plural = totalErrors === 1 ? "" : "s";
 
 	console.log(`Downloaded swag-images with ${errorText} error${plural}`);
 
-	return totalErrors === 0 || !(!process.env.NETLIFY || (process.env.NETLIFY && process.env.CONTEXT === 'production'));
+	return (
+		totalErrors === 0 ||
+		!(
+			!process.env.NETLIFY ||
+			(process.env.NETLIFY && process.env.CONTEXT === "production")
+		)
+	);
 };


### PR DESCRIPTION
- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->

#### Changes Made
- **Updated `gulp.task("swag-img:download")` in `gulpfile.js`** to handle image download errors gracefully by logging warnings instead of throwing errors.
- Enhanced the `downloadSingleImage` function to implement retry logic for failed downloads, allowing for up to 3 attempts.
- Improved error logging and cleanup for partial downloads, ensuring smoother build processes.

### Reference
Check issue #1283 for reference.  
Note: I did this under Hacktoberfest.

### Additional Note
P.S. I am using a VS Code extension called Prettier, which formats the code automatically. This is why there are so many changes in the formatting.

<!-- Thanks for contributing! -->
